### PR TITLE
Update Python requirement to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 packages = [{ include = "rooBroker", from = "src" }]
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.10"
 rich = "^13.0.0"
 requests = "^2.31.0"
 typing-extensions = "^4.5.0"
@@ -31,7 +31,7 @@ pre-commit = "^4.2.0"
 detect-secrets = "^1.5.0"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
## Summary
- update minimum Python version to 3.10 in `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_6841b03e42f08330b6276e98a5cdf35b