### PR TITLE
Fix markup closing tag for proxy message

### DIFF
--- a/src/rooBroker/interactive_actions.py
+++ b/src/rooBroker/interactive_actions.py
@@ -156,7 +156,7 @@ async def launch_context_proxy(layout: InteractiveLayout):
             console=layout.console,
         )
         layout.prompt.add_message(
-            f"[green]Proxy running on port {DEFAULT_PROXY_PORT}[green]"
+            f"[green]Proxy running on port {DEFAULT_PROXY_PORT}[/green]"
         )
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- fix Rich markup closing tag in `launch_context_proxy`

## Testing
- `pre-commit run --files src/rooBroker/interactive_actions.py` *(fails: E501 line too long)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b05af5a08330baeb515702f1bf7d